### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/get_kmeans.py
+++ b/get_kmeans.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 # This script is modified from https://github.com/lars76/kmeans-anchor-boxes
 
+from __future__ import print_function
 import numpy as np
 
 def iou(box, clusters):
@@ -130,8 +131,8 @@ if __name__ == '__main__':
         anchor_string += '{},{}, '.format(anchor[0], anchor[1])
     anchor_string = anchor_string[:-2]
 
-    print 'anchors are:'
-    print anchor_string
-    print 'the average iou is:'
-    print ave_iou
+    print('anchors are:')
+    print(anchor_string)
+    print('the average iou is:')
+    print(ave_iou)
 


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.